### PR TITLE
Update key generation path

### DIFF
--- a/scripts/gen_ssh_key.sh
+++ b/scripts/gen_ssh_key.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 
-mkdir -p $PWD/.ssh
+mkdir -p $HOME/.ssh
 # ssh-keygen -t rsa -f $PWD/../.ssh/id_rsa -C $USER
-ssh-keygen -f $PWD/../.ssh/id_rsa
+ssh-keygen -f $HOME/.ssh/id_rsa


### PR DESCRIPTION
Currently concatenating `../(reference for parent directory)` after $PWD variable causes an error like this below:

`Saving key "/Users/hyungsukkang/test/test-key/../.ssh/id_rsa" failed: No such file or directory`

To solve this, I replaced $PWD to $HOME to locate to the `.ssh` folder in the home directory of a computer. 

I am not sure if this is what you meant to add, but it resolves error for now.
